### PR TITLE
fix: 5 corrections gameplay (PvP, déco, bordure, drop, pouvoirs)

### DIFF
--- a/plugin/src/main/java/fr/medsir/toaruhc/listeners/GameListener.java
+++ b/plugin/src/main/java/fr/medsir/toaruhc/listeners/GameListener.java
@@ -38,7 +38,7 @@ public class GameListener implements Listener {
         if (!plugin.getGameManager().isRunning()) return;
         Player player = event.getPlayer();
         UHCPlayer u = plugin.getGameManager().getUHCPlayer(player);
-        if (u != null && u.isAlive()) plugin.getGameManager().handlePlayerDeath(player, null);
+        if (u != null && u.isAlive()) plugin.getGameManager().handlePlayerQuit(player);
         plugin.getPowerManager().removeEnergyBar(player.getUniqueId());
     }
 }

--- a/plugin/src/main/java/fr/medsir/toaruhc/listeners/PowerListener.java
+++ b/plugin/src/main/java/fr/medsir/toaruhc/listeners/PowerListener.java
@@ -1,6 +1,7 @@
 package fr.medsir.toaruhc.listeners;
 
 import fr.medsir.toaruhc.ToaruUHC;
+import fr.medsir.toaruhc.core.GameState;
 import fr.medsir.toaruhc.models.UHCPlayer;
 import fr.medsir.toaruhc.powers.Power;
 import fr.medsir.toaruhc.powers.esper.AcceleratorPower;
@@ -49,6 +50,13 @@ public class PowerListener implements Listener {
         UHCPlayer u = plugin.getGameManager().getUHCPlayer(player);
         if (u == null || !u.isAlive()) return;
 
+        // Pouvoirs disponibles uniquement en phase PvP et Endgame
+        GameState state = plugin.getGameManager().getState();
+        if (state != GameState.PVP && state != GameState.ENDGAME) {
+            player.sendMessage("§c⚠ Les pouvoirs ne sont disponibles qu'à partir du PvP !");
+            return;
+        }
+
         Power power = u.getPower();
         if (power == null) return;
 
@@ -74,7 +82,7 @@ public class PowerListener implements Listener {
             (current != null && current.getType() == POWER_ITEM && isPowerItem(current)) ||
             (cursor  != null && cursor.getType()  == POWER_ITEM && isPowerItem(cursor));
 
-        if (isMovingPowerItem || event.getSlot() == 0) {
+        if (isMovingPowerItem) {
             event.setCancelled(true);
         }
     }

--- a/plugin/src/main/java/fr/medsir/toaruhc/managers/GameManager.java
+++ b/plugin/src/main/java/fr/medsir/toaruhc/managers/GameManager.java
@@ -22,7 +22,7 @@ public class GameManager {
     public GameManager(ToaruUHC plugin) {
         this.plugin = plugin;
         this.miningDuration       = plugin.getConfig().getInt("game.mining-phase-duration", 20);
-        this.borderSize           = plugin.getConfig().getInt("game.border-size", 1000);
+        this.borderSize           = plugin.getConfig().getInt("game.border-size", 4000);
         this.borderFinalSize      = plugin.getConfig().getInt("game.border-final-size", 50);
         this.borderShrinkDuration = plugin.getConfig().getInt("game.border-shrink-duration", 30);
         this.minPlayers           = plugin.getConfig().getInt("game.min-players", 1);
@@ -43,6 +43,7 @@ public class GameManager {
 
     public void startGame(boolean testing, String roleName) {
         if (state != GameState.WAITING) return;
+        setPvP(false); // Désactiver le PvP dès le lancement
         this.testing = testing;
         for (Player p : Bukkit.getOnlinePlayers())
             players.put(p.getUniqueId(), new UHCPlayer(p.getUniqueId(), maxAim, maxMana));
@@ -199,6 +200,20 @@ public class GameManager {
         String killerName = (killer != null) ? killer.getName() : "l'environnement";
         broadcastPrefix("§c☠ " + victim.getName() + " §7éliminé par §c" + killerName + " §8(" + uhcVictim.getKills() + " kills)");
         if (killer != null) { UHCPlayer k = players.get(killer.getUniqueId()); if (k != null) k.addKill(); }
+        checkWinCondition();
+    }
+
+    /**
+     * Gère la déconnexion d'un joueur en cours de partie :
+     * le retire silencieusement (pas de message de mort, pas de kill crédité).
+     */
+    public void handlePlayerQuit(Player player) {
+        UHCPlayer u = players.get(player.getUniqueId());
+        if (u == null || !u.isAlive()) return;
+        u.setAlive(false);
+        if (u.getPower() != null) u.getPower().deactivate(u);
+        plugin.getPowerManager().removeEnergyBar(player.getUniqueId());
+        broadcastPrefix("§7☁ " + player.getName() + " §7a quitté la partie.");
         checkWinCondition();
     }
 


### PR DESCRIPTION
- setPvP(false) immédiatement au lancement (plus 10s de délai)
- handlePlayerQuit() : déconnexion silencieuse sans mort ni kill crédité
- Bordure par défaut portée à 4000 (-2000 → +2000)
- onInventoryClick : suppression du blocage abusif du slot 0 (item en slot 8)
- onRightClick : pouvoirs bloqués avant la phase PvP (MINING / STARTING)